### PR TITLE
Add leave classroom functionality

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
@@ -244,7 +244,13 @@ class UsersController(
         user: User,
         userClassroom: UserClassroom,
     ): ResponseEntity<Any> {
-        if (userClassroom.role != TEACHER) throw AuthorizationException("User is not a teacher")
+        if (userClassroom.role != TEACHER && user.uid != userId)
+            throw AuthorizationException("Not enough permissions to remove another user")
+
+        // Don't allow teachers to leave if they are the only teacher in the classroom
+        val isTeacherLeaving = userClassroom.role == TEACHER && user.uid == userId
+        if (isTeacherLeaving && usersDb.getTeachersInClassroomCount(userClassroom.classroom.cid) == 1)
+            throw AuthorizationException("Cannot leave classroom as you are the only teacher")
 
         usersDb.deleteUserFromClassroom(orgId, classroomNumber, userId)
 
@@ -350,7 +356,8 @@ class UsersController(
         user: User,
         userClassroom: UserClassroom,
     ): ResponseEntity<Any> {
-        if (userClassroom.role != TEACHER && user.uid != userId) throw AuthorizationException("Not enough permissions to remove another user")
+        if (userClassroom.role != TEACHER && user.uid != userId)
+            throw AuthorizationException("Not enough permissions to remove another user")
 
         val team = teamsDb.getTeam(orgId, classroomNumber, teamNumber)
         val userToRemove = usersDb.getUserById(userId)

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
@@ -250,7 +250,7 @@ class UsersController(
         // Don't allow teachers to leave if they are the only teacher in the classroom
         val isTeacherLeaving = userClassroom.role == TEACHER && user.uid == userId
         if (isTeacherLeaving && usersDb.getTeachersInClassroomCount(userClassroom.classroom.cid) == 1)
-            throw AuthorizationException("Cannot leave classroom as you are the only teacher")
+            throw AuthorizationException("Unable to leave classroom as there are no other teachers")
 
         usersDb.deleteUserFromClassroom(orgId, classroomNumber, userId)
 

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/UsersDb.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/UsersDb.kt
@@ -35,6 +35,8 @@ private const val GET_USER_IN_CLASSROOM_QUERY =
 private const val GET_USERS_IN_CLASSROOM_COUNT =
     "SELECT COUNT(uid) as count FROM USER_CLASSROOM where cid IN " +
         "(SELECT cid FROM CLASSROOM WHERE org_id = :orgId AND number = :classroomNumber)"
+private const val GET_TEACHERS_IN_CLASSROOM_COUNT =
+    "SELECT COUNT(uid) as count FROM USER_CLASSROOM where cid = :classroomId AND type = 'teacher'"
 
 private const val ADD_USER_TO_CLASSROOM_QUERY =
     "INSERT INTO USER_CLASSROOM VALUES(:role, :userId, :classroomId)"
@@ -153,6 +155,12 @@ class UsersDb(
             mapOf("orgId" to orgId, "classroomNumber" to classroomNumber)
         )
 
+    fun getTeachersInClassroomCount(classroomId: Int) =
+        jdbi.getOne(
+            GET_TEACHERS_IN_CLASSROOM_COUNT,
+            Int::class.java,
+            mapOf("classroomId" to classroomId)
+        )
 
     fun addOrEditUserInClassroom(orgId: Int, classroomNumber: Int, userId: Int, role: String) {
         val classroomId = classroomsDb.getClassroomByNumber(orgId, classroomNumber).cid


### PR DESCRIPTION
This PR adds the possibility to leave a classroom as a student and adds restrictions to leaving a classroom as a teacher:
• If the authenticated user is a student, the user being removed must be itself.
• If the authenticated user is a teacher, it is only possible to leave the classroom if there are more teachers in the classroom (this prevents situations in where a classroom has no teachers, making it unusable)

Closes GH-41.