### PR TITLE
Add GitHub team name to Team entity

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/InvitationsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/InvitationsController.kt
@@ -9,7 +9,7 @@ import org.ionproject.codegarten.Routes.includeHost
 import org.ionproject.codegarten.controllers.api.actions.InvitationActions
 import org.ionproject.codegarten.controllers.models.AssignmentInvitationOutputModel
 import org.ionproject.codegarten.controllers.models.ClassroomInvitationOutputModel
-import org.ionproject.codegarten.controllers.models.TeamOutputModel
+import org.ionproject.codegarten.controllers.models.TeamItemOutputModel
 import org.ionproject.codegarten.controllers.models.TeamsOutputModel
 import org.ionproject.codegarten.database.dto.User
 import org.ionproject.codegarten.database.dto.isFromClassroom
@@ -114,7 +114,7 @@ class InvitationsController(
             pageSize = teams.size,
         ).toSirenObject(
             entities = teams.map {
-                TeamOutputModel(
+                TeamItemOutputModel(
                     id = it.tid,
                     number = it.number,
                     name = it.name,

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/TeamsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/TeamsController.kt
@@ -18,6 +18,7 @@ import org.ionproject.codegarten.controllers.api.actions.TeamActions.getDeleteTe
 import org.ionproject.codegarten.controllers.api.actions.TeamActions.getEditTeamAction
 import org.ionproject.codegarten.controllers.models.TeamCreateInputModel
 import org.ionproject.codegarten.controllers.models.TeamEditInputModel
+import org.ionproject.codegarten.controllers.models.TeamItemOutputModel
 import org.ionproject.codegarten.controllers.models.TeamOutputModel
 import org.ionproject.codegarten.controllers.models.TeamsOutputModel
 import org.ionproject.codegarten.database.dto.Installation
@@ -89,7 +90,7 @@ class TeamsController(
             pageSize = teams.size,
         ).toSirenObject(
             entities = teams.map {
-                TeamOutputModel(
+                TeamItemOutputModel(
                     id = it.tid,
                     number = it.number,
                     name = it.name,
@@ -150,6 +151,7 @@ class TeamsController(
             id = team.tid,
             number = team.number,
             name = team.name,
+            gitHubName = ghTeam.name,
             classroom = team.classroom_name,
             organization = ghTeam.organization.login
         ).toSirenObject(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Teams.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Teams.kt
@@ -7,6 +7,17 @@ class TeamOutputModel(
     val id: Int,
     val number: Int,
     val name: String,
+    val gitHubName: String,
+    val classroom: String,
+    val organization: String
+) : OutputModel() {
+    override fun getSirenClasses() = listOf(team)
+}
+
+class TeamItemOutputModel(
+    val id: Int,
+    val number: Int,
+    val name: String,
     val classroom: String,
     val organization: String
 ) : OutputModel() {


### PR DESCRIPTION
This PR adds the field `gitHubName` to `TeamOutputModel`. This change is visible on the API when viewing a team.
Closes GH-55.