### PR TITLE
Add user membership to Team entity

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/TeamsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/TeamsController.kt
@@ -152,6 +152,7 @@ class TeamsController(
             number = team.number,
             name = team.name,
             gitHubName = ghTeam.name,
+            isMember = userClassroom.role != TEACHER,
             classroom = team.classroom_name,
             organization = ghTeam.organization.login
         ).toSirenObject(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Teams.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Teams.kt
@@ -8,6 +8,7 @@ class TeamOutputModel(
     val number: Int,
     val name: String,
     val gitHubName: String,
+    val isMember: Boolean,
     val classroom: String,
     val organization: String
 ) : OutputModel() {


### PR DESCRIPTION
This PR adds the field `isMember` to `TeamOutputModel`. This change is visible on the API when viewing a team.

Closes GH-57.