### PR TITLE
Add teacher type in assignment participation

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Participants.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Participants.kt
@@ -20,7 +20,8 @@ class ParticipantItemOutputModel(
 
 enum class ParticipantTypes(val type: String) {
     USER("user"),
-    TEAM("team")
+    TEAM("team"),
+    TEACHER("teacher")
 }
 
 class ParticipantsOutputModel(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/UsersDb.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/UsersDb.kt
@@ -215,7 +215,7 @@ class UsersDb(
         return getUserMembershipInClassroom(classroom, userId)
     }
 
-    fun getUserMembershipInClassroom(classroom: Classroom, userId: Int): UserClassroom {
+    private fun getUserMembershipInClassroom(classroom: Classroom, userId: Int): UserClassroom {
         val maybeUserClassroom = jdbi.tryGetOne(
             GET_USER_CLASSROOM_QUERY,
             UserClassroomDto::class.java,


### PR DESCRIPTION
This PR improves the assignment participation route by including support for teachers. Instead of responding with a 404 status code for teachers, the API now responds with a status code of 200, providing the information that the authenticated user is a teacher.

Closes GH-61.