### PR TITLE
Fix issue when adding a team member that was not in classroom

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
@@ -336,7 +336,7 @@ class UsersController(
 
         val userToAddMembership = usersDb.getUserMembershipInClassroom(orgId, classroomNumber, userId)
         if (userToAddMembership.role == NOT_A_MEMBER) {
-            throw InvalidInputException("Cannot add a user that's not a classroom member")
+            throw ForbiddenException("Cannot add a user that's not a classroom member")
         }
 
         val team = teamsDb.getTeam(orgId, classroomNumber, teamNumber)

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
@@ -32,6 +32,7 @@ import org.ionproject.codegarten.database.dto.User
 import org.ionproject.codegarten.database.dto.UserClassroom
 import org.ionproject.codegarten.database.dto.UserClassroomMembership.NOT_A_MEMBER
 import org.ionproject.codegarten.database.dto.UserClassroomMembership.TEACHER
+import org.ionproject.codegarten.database.helpers.ClassroomsDb
 import org.ionproject.codegarten.database.helpers.TeamsDb
 import org.ionproject.codegarten.database.helpers.UsersDb
 import org.ionproject.codegarten.exceptions.ForbiddenException
@@ -62,6 +63,7 @@ import java.net.URI
 class UsersController(
     val usersDb: UsersDb,
     val teamsDb: TeamsDb,
+    val classroomsDb: ClassroomsDb,
     val gitHub: GitHubInterface,
     val cryptoUtils: CryptoUtils,
 ) {
@@ -332,8 +334,13 @@ class UsersController(
     ): ResponseEntity<Any> {
         if (userClassroom.role != TEACHER) throw ForbiddenException("User is not a teacher")
 
+        val userToAddMembership = usersDb.getUserMembershipInClassroom(orgId, classroomNumber, userId)
+        if (userToAddMembership.role == NOT_A_MEMBER) {
+            throw InvalidInputException("Cannot add a user that's not a classroom member")
+        }
+
         val team = teamsDb.getTeam(orgId, classroomNumber, teamNumber)
-        val userToAdd = usersDb.getUserById(userId)
+        val userToAdd = userToAddMembership.user!! // Should not be null since it's a member
 
         val githubUser = gitHub.getUser(userToAdd.gh_id, user.gh_token)
 


### PR DESCRIPTION
This PR fixes an issue where the API allowed users to be added to a team, even if said users were not in the classroom.

Closes GH-56.