### PR TITLE
Clean up user dependencies in classroom after leaving

### DIFF
--- a/code/sql/3_create_functions.sql
+++ b/code/sql/3_create_functions.sql
@@ -1,3 +1,4 @@
+-- Triggers for sequences
 CREATE FUNCTION func_create_installation_seq()
 RETURNS TRIGGER AS
 $$
@@ -78,6 +79,19 @@ $$
     BEGIN
         NEW.number = nextval('delivery_number_seq_' || NEW.aid);
         RETURN NEW;
+    END
+$$
+LANGUAGE 'plpgsql';
+
+
+-- Remove user dependencies when leaving a classroom
+CREATE FUNCTION func_cleanup_user_dependencies()
+RETURNS TRIGGER AS
+$$
+    BEGIN
+        DELETE FROM USER_ASSIGNMENT WHERE uid = OLD.uid;
+        DELETE FROM USER_TEAM WHERE uid = OLD.uid;
+        RETURN OLD;
     END
 $$
 LANGUAGE 'plpgsql';

--- a/code/sql/4_create_triggers.sql
+++ b/code/sql/4_create_triggers.sql
@@ -1,3 +1,4 @@
+-- Triggers for sequences
 CREATE TRIGGER trig_create_installation_seq
 AFTER INSERT ON INSTALLATION
 FOR EACH ROW 
@@ -37,3 +38,10 @@ CREATE TRIGGER trig_get_delivery_number
 BEFORE INSERT ON DELIVERY
 FOR EACH ROW 
 EXECUTE PROCEDURE func_get_delivery_number();
+
+
+-- Remove user dependencies when leaving a classroom
+CREATE TRIGGER trig_cleanup_user_dependencies
+BEFORE DELETE ON USER_CLASSROOM
+FOR EACH ROW
+EXECUTE PROCEDURE func_cleanup_user_dependencies();

--- a/code/sql/drop.sql
+++ b/code/sql/drop.sql
@@ -21,6 +21,7 @@ DROP TRIGGER IF EXISTS trig_get_assignment_number ON ASSIGNMENT;
 DROP TRIGGER IF EXISTS trig_cleanup_assignment_seq ON ASSIGNMENT;
 DROP TRIGGER IF EXISTS trig_get_team_number ON TEAM;
 DROP TRIGGER IF EXISTS trig_get_delivery_number ON DELIVERY;
+DROP TRIGGER IF EXISTS trig_cleanup_user_dependencies ON USER_CLASSROOM;
 
 DROP FUNCTION IF EXISTS func_create_installation_seq;
 DROP FUNCTION IF EXISTS func_cleanup_installation_seq;
@@ -30,6 +31,7 @@ DROP FUNCTION IF EXISTS func_get_assignment_number;
 DROP FUNCTION IF EXISTS func_cleanup_assignment_seq;
 DROP FUNCTION IF EXISTS func_get_team_number;
 DROP FUNCTION IF EXISTS func_get_delivery_number;
+DROP FUNCTION IF EXISTS func_cleanup_user_dependencies();
 
 DROP VIEW IF EXISTS V_DELIVERY;
 DROP VIEW IF EXISTS V_INVITECODE;


### PR DESCRIPTION
This PR implements an SQL trigger that cleans up the user's assignments and teams when leaving a classroom.

Closes GH-86.