### PR TITLE
Fix an issue when leaving a classroom

### DIFF
--- a/code/js/lib/repo/services/users.ts
+++ b/code/js/lib/repo/services/users.ts
@@ -129,7 +129,7 @@ function removeUserFromClassroom(orgId: number, classroomNumber: number, userId:
         .then(async res => {
             return { 
                 status: res.status,
-                content: await res.json()
+                content: res.status != 200 ? await res.json() : null
             } as ApiResponse
         })
 }


### PR DESCRIPTION
This PR fixes an issue where an incorrect error message would appear in the web app whenever a user left a classroom