### PR TITLE
Implement submit and delete participants deliveries functionalities

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
@@ -39,7 +39,9 @@ import org.ionproject.codegarten.database.helpers.DeliveriesDb
 import org.ionproject.codegarten.database.helpers.TeamsDb
 import org.ionproject.codegarten.database.helpers.UsersDb
 import org.ionproject.codegarten.exceptions.ForbiddenException
+import org.ionproject.codegarten.exceptions.HttpRequestException
 import org.ionproject.codegarten.exceptions.InvalidInputException
+import org.ionproject.codegarten.exceptions.NotFoundException
 import org.ionproject.codegarten.pipeline.argumentresolvers.Pagination
 import org.ionproject.codegarten.pipeline.interceptors.RequiresUserInAssignment
 import org.ionproject.codegarten.remote.github.GitHubInterface
@@ -175,155 +177,6 @@ class DeliveriesController(
         ).toResponseEntity(HttpStatus.OK)
     }
 
-    @RequiresUserInAssignment
-    @GetMapping(DELIVERIES_OF_PARTICIPANT_HREF)
-    fun getAllUserDeliveries(
-        @PathVariable(name = ORG_PARAM) orgId: Int,
-        @PathVariable(name = CLASSROOM_PARAM) classroomNumber: Int,
-        @PathVariable(name = ASSIGNMENT_PARAM) assignmentNumber: Int,
-        @PathVariable(name = PARTICIPANT_PARAM) participantId: Int,
-        pagination: Pagination,
-        user: User,
-        userClassroom: UserClassroom,
-        assignment: Assignment
-    ): ResponseEntity<Response> {
-        val isGroupAssignment = assignment.isGroupAssignment()
-        val isTeacher = userClassroom.role == TEACHER
-
-        val repoId =
-            if (isGroupAssignment) {
-                val team = teamsDb.getTeam(orgId, classroomNumber, participantId)
-                if (!isTeacher && !teamsDb.isUserInTeam(team.tid, user.uid))
-                    throw ForbiddenException("Not enough permission to see deliveries")
-
-                teamsDb.getTeamAssignment(assignment.aid, team.tid).repo_id
-            } else {
-                if (!isTeacher && user.uid != participantId)
-                    throw ForbiddenException("Not enough permission to see deliveries")
-
-                usersDb.getUserAssignment(orgId, classroomNumber, assignmentNumber, participantId).repo_id
-            }
-
-        val deliveries = deliveriesDb.getDeliveriesOfAssignment(orgId, classroomNumber, assignmentNumber, pagination.page, pagination.limit)
-        val deliveriesCount = deliveriesDb.getDeliveriesOfAssignmentCount(orgId, classroomNumber, assignmentNumber)
-
-        val ghTags = gitHub.getAllTagsFromRepo(repoId, user.gh_token)
-        val org = gitHub.getOrgById(orgId, user.gh_token)
-
-        return DeliveriesOutputModel(
-            assignment = assignment.name,
-            classroom = userClassroom.classroom.name,
-            organization = org.login,
-            collectionSize = deliveriesCount,
-            pageIndex = pagination.page,
-            pageSize = deliveries.size
-        ).toSirenObject(
-            entities = deliveries.map {
-                ParticipantDeliveryItemOutputModel(
-                    id = it.did,
-                    number = it.number,
-                    tag = it.tag,
-                    dueDate = it.due_date,
-                    isDelivered = ghTags.any { tag -> tag.name == it.tag },
-                    assignment = it.assignment_name,
-                    classroom = it.classroom_name,
-                    organization = org.login
-                ).toSirenObject(
-                    rel = listOf("item"),
-                    links = listOf(
-                        SirenLink(listOf(SELF_PARAM),
-                            getDeliveryOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId, it.number).includeHost()),
-                        SirenLink(listOf("participant-deliveries"),
-                            getDeliveriesOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId).includeHost()),
-                        SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
-                        SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
-                        SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
-                        SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
-                        SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login)),
-                        SirenLink(listOf("participant"),
-                            if (isGroupAssignment) getUserByIdUri(participantId).includeHost()
-                            else getTeamByNumberUri(orgId, classroomNumber, participantId)
-                        )
-                    )
-                )
-            },
-            links = Routes.createSirenLinkListForPagination(
-                Routes.getAssignmentsUri(orgId, classroomNumber).includeHost(),
-                pagination.page,
-                pagination.limit,
-                deliveriesCount
-            ) + listOf(
-                SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
-                SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
-                SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
-                SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
-                SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login)),
-                SirenLink(listOf("participant"),
-                    if (isGroupAssignment) getUserByIdUri(participantId).includeHost()
-                    else getTeamByNumberUri(orgId, classroomNumber, participantId))
-            )
-        ).toResponseEntity(HttpStatus.OK)
-    }
-
-    @RequiresUserInAssignment
-    @GetMapping(DELIVERY_OF_PARTICIPANT_HREF)
-    fun getUserDelivery(
-        @PathVariable(name = ORG_PARAM) orgId: Int,
-        @PathVariable(name = CLASSROOM_PARAM) classroomNumber: Int,
-        @PathVariable(name = ASSIGNMENT_PARAM) assignmentNumber: Int,
-        @PathVariable(name = PARTICIPANT_PARAM) participantId: Int,
-        @PathVariable(name = DELIVERY_PARAM) deliveryNumber: Int,
-        user: User,
-        userClassroom: UserClassroom,
-        assignment: Assignment
-    ): ResponseEntity<Response> {
-        val isGroupAssignment = assignment.isGroupAssignment()
-        val isTeacher = userClassroom.role == TEACHER
-
-        val repoId =
-            if (isGroupAssignment) {
-                val team = teamsDb.getTeam(orgId, classroomNumber, participantId)
-                if (!isTeacher && !teamsDb.isUserInTeam(team.tid, user.uid))
-                    throw ForbiddenException("Not enough permission to see deliveries")
-
-                teamsDb.getTeamAssignment(assignment.aid, team.tid).repo_id
-            } else {
-                if (!isTeacher && user.uid != participantId)
-                    throw ForbiddenException("Not enough permission to see deliveries")
-
-                usersDb.getUserAssignment(orgId, classroomNumber, assignmentNumber, participantId).repo_id
-            }
-
-        val delivery = deliveriesDb.getDeliveryByNumber(orgId, classroomNumber, assignmentNumber, deliveryNumber)
-        val tag = gitHub.tryGetTagFromRepo(repoId, delivery.tag, user.gh_token)
-        val org = gitHub.getOrgById(orgId, user.gh_token)
-
-        return ParticipantDeliveryOutputModel(
-            id = delivery.did,
-            number = delivery.number,
-            tag = delivery.tag,
-            dueDate = delivery.due_date,
-            isDelivered = tag.isPresent,
-            deliverDate = if (tag.isEmpty) null else tag.get().date,
-            assignment = delivery.assignment_name,
-            classroom = delivery.classroom_name,
-            organization = org.login
-        ).toSirenObject(
-            links = listOf(
-                SirenLink(listOf(SELF_PARAM), getDeliveryOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId, deliveryNumber).includeHost()),
-                SirenLink(listOf("participant-deliveries"), getDeliveriesOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId).includeHost()),
-                SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
-                SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
-                SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
-                SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
-                SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login)),
-                SirenLink(listOf("participant"),
-                    if (isGroupAssignment) getUserByIdUri(participantId).includeHost()
-                    else getTeamByNumberUri(orgId, classroomNumber, participantId)
-                )
-            )
-        ).toResponseEntity(HttpStatus.OK)
-    }
 
     @RequiresUserInAssignment
     @PostMapping(DELIVERIES_HREF)
@@ -430,6 +283,248 @@ class DeliveriesController(
         if (userClassroom.role != TEACHER) throw ForbiddenException("User is not a teacher")
 
         deliveriesDb.deleteDelivery(orgId, classroomNumber, assignmentNumber, deliveryNumber)
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(null)
+    }
+
+    @RequiresUserInAssignment
+    @GetMapping(DELIVERIES_OF_PARTICIPANT_HREF)
+    fun getAllParticipantDeliveries(
+        @PathVariable(name = ORG_PARAM) orgId: Int,
+        @PathVariable(name = CLASSROOM_PARAM) classroomNumber: Int,
+        @PathVariable(name = ASSIGNMENT_PARAM) assignmentNumber: Int,
+        @PathVariable(name = PARTICIPANT_PARAM) participantId: Int,
+        pagination: Pagination,
+        user: User,
+        userClassroom: UserClassroom,
+        assignment: Assignment
+    ): ResponseEntity<Response> {
+        val isGroupAssignment = assignment.isGroupAssignment()
+        val isTeacher = userClassroom.role == TEACHER
+
+        val repoId =
+            if (isGroupAssignment) {
+                val team = teamsDb.getTeam(orgId, classroomNumber, participantId)
+                if (!isTeacher && !teamsDb.isUserInTeam(team.tid, user.uid))
+                    throw ForbiddenException("Not enough permission to see deliveries")
+
+                teamsDb.getTeamAssignment(assignment.aid, team.tid).repo_id
+            } else {
+                if (!isTeacher && user.uid != participantId)
+                    throw ForbiddenException("Not enough permission to see deliveries")
+
+                usersDb.getUserAssignment(orgId, classroomNumber, assignmentNumber, participantId).repo_id
+            }
+
+        val deliveries = deliveriesDb.getDeliveriesOfAssignment(orgId, classroomNumber, assignmentNumber, pagination.page, pagination.limit)
+        val deliveriesCount = deliveriesDb.getDeliveriesOfAssignmentCount(orgId, classroomNumber, assignmentNumber)
+
+        val ghTags = gitHub.getAllTagsFromRepo(repoId, user.gh_token)
+        val org = gitHub.getOrgById(orgId, user.gh_token)
+
+        return DeliveriesOutputModel(
+            assignment = assignment.name,
+            classroom = userClassroom.classroom.name,
+            organization = org.login,
+            collectionSize = deliveriesCount,
+            pageIndex = pagination.page,
+            pageSize = deliveries.size
+        ).toSirenObject(
+            entities = deliveries.map {
+                ParticipantDeliveryItemOutputModel(
+                    id = it.did,
+                    number = it.number,
+                    tag = it.tag,
+                    dueDate = it.due_date,
+                    isDelivered = ghTags.any { tag -> tag.name == it.tag },
+                    assignment = it.assignment_name,
+                    classroom = it.classroom_name,
+                    organization = org.login
+                ).toSirenObject(
+                    rel = listOf("item"),
+                    links = listOf(
+                        SirenLink(listOf(SELF_PARAM),
+                            getDeliveryOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId, it.number).includeHost()),
+                        SirenLink(listOf("participant-deliveries"),
+                            getDeliveriesOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId).includeHost()),
+                        SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
+                        SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
+                        SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
+                        SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
+                        SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login)),
+                        SirenLink(listOf("participant"),
+                            if (isGroupAssignment) getUserByIdUri(participantId).includeHost()
+                            else getTeamByNumberUri(orgId, classroomNumber, participantId)
+                        )
+                    )
+                )
+            },
+            links = Routes.createSirenLinkListForPagination(
+                Routes.getAssignmentsUri(orgId, classroomNumber).includeHost(),
+                pagination.page,
+                pagination.limit,
+                deliveriesCount
+            ) + listOf(
+                SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
+                SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
+                SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
+                SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
+                SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login)),
+                SirenLink(listOf("participant"),
+                    if (isGroupAssignment) getUserByIdUri(participantId).includeHost()
+                    else getTeamByNumberUri(orgId, classroomNumber, participantId))
+            )
+        ).toResponseEntity(HttpStatus.OK)
+    }
+
+    @RequiresUserInAssignment
+    @GetMapping(DELIVERY_OF_PARTICIPANT_HREF)
+    fun getParticipantDelivery(
+        @PathVariable(name = ORG_PARAM) orgId: Int,
+        @PathVariable(name = CLASSROOM_PARAM) classroomNumber: Int,
+        @PathVariable(name = ASSIGNMENT_PARAM) assignmentNumber: Int,
+        @PathVariable(name = PARTICIPANT_PARAM) participantId: Int,
+        @PathVariable(name = DELIVERY_PARAM) deliveryNumber: Int,
+        user: User,
+        userClassroom: UserClassroom,
+        assignment: Assignment
+    ): ResponseEntity<Response> {
+        val isGroupAssignment = assignment.isGroupAssignment()
+        val isTeacher = userClassroom.role == TEACHER
+
+        val repoId =
+            if (isGroupAssignment) {
+                val team = teamsDb.getTeam(orgId, classroomNumber, participantId)
+                if (!isTeacher && !teamsDb.isUserInTeam(team.tid, user.uid))
+                    throw ForbiddenException("Not enough permission to see deliveries")
+
+                teamsDb.getTeamAssignment(assignment.aid, team.tid).repo_id
+            } else {
+                if (!isTeacher && user.uid != participantId)
+                    throw ForbiddenException("Not enough permission to see deliveries")
+
+                usersDb.getUserAssignment(orgId, classroomNumber, assignmentNumber, participantId).repo_id
+            }
+
+        val delivery = deliveriesDb.getDeliveryByNumber(orgId, classroomNumber, assignmentNumber, deliveryNumber)
+        val tag = gitHub.tryGetTagFromRepo(repoId, delivery.tag, user.gh_token)
+        val org = gitHub.getOrgById(orgId, user.gh_token)
+
+        return ParticipantDeliveryOutputModel(
+            id = delivery.did,
+            number = delivery.number,
+            tag = delivery.tag,
+            dueDate = delivery.due_date,
+            isDelivered = tag.isPresent,
+            deliverDate = if (tag.isEmpty) null else tag.get().date,
+            assignment = delivery.assignment_name,
+            classroom = delivery.classroom_name,
+            organization = org.login
+        ).toSirenObject(
+            links = listOf(
+                SirenLink(listOf(SELF_PARAM), getDeliveryOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId, deliveryNumber).includeHost()),
+                SirenLink(listOf("participant-deliveries"), getDeliveriesOfParticipantUri(orgId, classroomNumber, assignmentNumber, participantId).includeHost()),
+                SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
+                SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
+                SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
+                SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
+                SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login)),
+                SirenLink(listOf("participant"),
+                    if (isGroupAssignment) getUserByIdUri(participantId).includeHost()
+                    else getTeamByNumberUri(orgId, classroomNumber, participantId)
+                )
+            )
+        ).toResponseEntity(HttpStatus.OK)
+    }
+
+    @RequiresUserInAssignment
+    @PutMapping(DELIVERY_OF_PARTICIPANT_HREF)
+    fun submitParticipantDelivery(
+        @PathVariable(name = ORG_PARAM) orgId: Int,
+        @PathVariable(name = CLASSROOM_PARAM) classroomNumber: Int,
+        @PathVariable(name = ASSIGNMENT_PARAM) assignmentNumber: Int,
+        @PathVariable(name = PARTICIPANT_PARAM) participantId: Int,
+        @PathVariable(name = DELIVERY_PARAM) deliveryNumber: Int,
+        user: User,
+        userClassroom: UserClassroom,
+        assignment: Assignment
+    ): ResponseEntity<Any> {
+        if (userClassroom.role == TEACHER)
+            throw ForbiddenException("No permission to submit a delivery for a participant")
+
+        val isGroupAssignment = assignment.isGroupAssignment()
+        val repoId =
+            if (isGroupAssignment) {
+                val team = teamsDb.getTeam(orgId, classroomNumber, participantId)
+                if (!teamsDb.isUserInTeam(team.tid, user.uid))
+                    throw ForbiddenException("No permission to submit a delivery for another participant")
+
+                teamsDb.getTeamAssignment(assignment.aid, team.tid).repo_id
+            } else {
+                if (user.uid != participantId)
+                    throw ForbiddenException("No permission to submit a delivery for another participant")
+
+                usersDb.getUserAssignment(orgId, classroomNumber, assignmentNumber, participantId).repo_id
+            }
+
+        val delivery = deliveriesDb.getDeliveryByNumber(orgId, classroomNumber, assignmentNumber, deliveryNumber)
+        try {
+            gitHub.createReleaseInRepo(repoId, delivery.tag, user.gh_token)
+        } catch(ex: HttpRequestException) {
+            if (ex.status != HttpStatus.UNPROCESSABLE_ENTITY.value())
+                throw ex
+
+            //TODO: Throw exception if tag already exists (Maybe 409 Conflict status code)
+            throw TODO()
+        }
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(null)
+    }
+
+    @RequiresUserInAssignment
+    @DeleteMapping(DELIVERY_OF_PARTICIPANT_HREF)
+    fun deleteParticipantDelivery(
+        @PathVariable(name = ORG_PARAM) orgId: Int,
+        @PathVariable(name = CLASSROOM_PARAM) classroomNumber: Int,
+        @PathVariable(name = ASSIGNMENT_PARAM) assignmentNumber: Int,
+        @PathVariable(name = PARTICIPANT_PARAM) participantId: Int,
+        @PathVariable(name = DELIVERY_PARAM) deliveryNumber: Int,
+        user: User,
+        userClassroom: UserClassroom,
+        assignment: Assignment
+    ): ResponseEntity<Response> {
+        if (userClassroom.role == TEACHER)
+            throw ForbiddenException("No permission to delete a delivery for a participant")
+
+        val isGroupAssignment = assignment.isGroupAssignment()
+        val repoId =
+            if (isGroupAssignment) {
+                val team = teamsDb.getTeam(orgId, classroomNumber, participantId)
+                if (!teamsDb.isUserInTeam(team.tid, user.uid))
+                    throw ForbiddenException("No permission to delete a delivery for another participant")
+
+                teamsDb.getTeamAssignment(assignment.aid, team.tid).repo_id
+            } else {
+                if (user.uid != participantId)
+                    throw ForbiddenException("No permission to delete a delivery for another participant")
+
+                usersDb.getUserAssignment(orgId, classroomNumber, assignmentNumber, participantId).repo_id
+            }
+
+        val delivery = deliveriesDb.getDeliveryByNumber(orgId, classroomNumber, assignmentNumber, deliveryNumber)
+
+        try {
+            gitHub.deleteTagFromRepo(repoId, delivery.tag, user.gh_token)
+        } catch(ex: HttpRequestException) {
+            if (ex.status != HttpStatus.UNPROCESSABLE_ENTITY.value())
+                throw ex
+
+            throw NotFoundException("Tag does not exist in the repository")
+        }
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
@@ -38,6 +38,7 @@ import org.ionproject.codegarten.database.dto.isGroupAssignment
 import org.ionproject.codegarten.database.helpers.DeliveriesDb
 import org.ionproject.codegarten.database.helpers.TeamsDb
 import org.ionproject.codegarten.database.helpers.UsersDb
+import org.ionproject.codegarten.exceptions.ConflictException
 import org.ionproject.codegarten.exceptions.ForbiddenException
 import org.ionproject.codegarten.exceptions.HttpRequestException
 import org.ionproject.codegarten.exceptions.InvalidInputException
@@ -476,8 +477,7 @@ class DeliveriesController(
             if (ex.status != HttpStatus.UNPROCESSABLE_ENTITY.value())
                 throw ex
 
-            //TODO: Throw exception if tag already exists (Maybe 409 Conflict status code)
-            throw TODO()
+            throw ConflictException("Delivery has already been submitted")
         }
 
         return ResponseEntity

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ParticipantsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ParticipantsController.kt
@@ -314,7 +314,6 @@ class ParticipantsController(
         userClassroom: UserClassroom,
         assignment: Assignment
     ): ResponseEntity<Response> {
-        // TODO: Add Repo Links to participants
         val isGroupAssignment = assignment.isGroupAssignment()
         val isTeacher = userClassroom.role == TEACHER
 

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/im/AuthCodeController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/im/AuthCodeController.kt
@@ -20,6 +20,7 @@ import org.ionproject.codegarten.exceptions.ServerErrorException
 import org.ionproject.codegarten.remote.github.GitHubInterface
 import org.ionproject.codegarten.utils.CryptoUtils
 import org.jdbi.v3.core.JdbiException
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -54,7 +55,7 @@ class AuthCodeController(
         }
 
         return ResponseEntity
-            .status(302)
+            .status(HttpStatus.FOUND)
             .header("Location", gitHub.getAuthUri(stateToSend).toString())
             .body(null)
     }
@@ -104,7 +105,7 @@ class AuthCodeController(
         }
 
         return ResponseEntity
-            .status(302)
+            .status(HttpStatus.FOUND)
             .header("Location", redirectUri)
             .body(null)
     }

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/im/GhAppInstallationController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/im/GhAppInstallationController.kt
@@ -7,6 +7,7 @@ import org.ionproject.codegarten.database.helpers.InstallationsDb
 import org.ionproject.codegarten.remote.github.GitHubInterface
 import org.ionproject.codegarten.remote.github.responses.GitHubAccountType.ORGANIZATION
 import org.ionproject.codegarten.utils.CryptoUtils
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -22,7 +23,7 @@ class GhAppInstallationController(
     @GetMapping(GH_INSTALLATIONS_HREF)
     fun installToOrg() : ResponseEntity<Any> {
         return ResponseEntity
-            .status(302)
+            .status(HttpStatus.FOUND)
             .header("Location", gitHub.getInstallationUri().toString())
             .body(null)
     }

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/exceptions/ConflictException.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/exceptions/ConflictException.kt
@@ -1,0 +1,3 @@
+package org.ionproject.codegarten.exceptions
+
+class ConflictException(message: String) : Exception(message)

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/pipeline/exceptionhandling/ExceptionHandler.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/pipeline/exceptionhandling/ExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.ionproject.codegarten.database.PsqlErrorCode
 import org.ionproject.codegarten.database.getPsqlErrorCode
 import org.ionproject.codegarten.exceptions.AuthorizationException
 import org.ionproject.codegarten.exceptions.ClientException
+import org.ionproject.codegarten.exceptions.ConflictException
 import org.ionproject.codegarten.exceptions.ForbiddenException
 import org.ionproject.codegarten.exceptions.HttpRequestException
 import org.ionproject.codegarten.exceptions.InvalidInputException
@@ -140,6 +141,19 @@ class ExceptionHandler {
             URI("/problems/invalid-input").includeHost(),
             "Invalid Input",
             HttpStatus.BAD_REQUEST,
+            ex.localizedMessage,
+            request.requestURI
+        )
+
+    @ExceptionHandler(value = [ConflictException::class])
+    private fun handleConflictException(
+        ex: ConflictException,
+        request: HttpServletRequest
+    ): ResponseEntity<Response> =
+        handleExceptionResponse(
+            URI("/problems/resource-conflict").includeHost(),
+            "Resource Conflict",
+            HttpStatus.CONFLICT,
             ex.localizedMessage,
             request.requestURI
         )

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/remote/github/GitHubInterface.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/remote/github/GitHubInterface.kt
@@ -39,6 +39,7 @@ import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubRepoByIdUri
 import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubRepoByNameUri
 import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubRepoCollaboratorUri
 import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubRepoGenerateByIdUri
+import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubRepoReleasesByIdUri
 import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubReposOfOrgUri
 import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubTagNameFromRef
 import org.ionproject.codegarten.remote.github.GitHubRoutes.getGitHubTeamByIdUri
@@ -294,6 +295,29 @@ class GitHubInterface(
 
             Optional.empty()
         }
+    }
+
+    fun createReleaseInRepo(repoId: Int, tag: String, ghToken: String) {
+        val json = mapper.createObjectNode()
+        json.put("tag_name", tag)
+        json.put("body", "Delivery of '$tag'")
+        val body = mapper.writeValueAsString(json)
+
+        val req = Request.Builder()
+            .from(getGitHubRepoReleasesByIdUri(repoId), ghAppProperties.name, ghToken)
+            .post(body.toRequestBody(MEDIA_TYPE_JSON))
+            .build()
+
+        httpClient.call(req)
+    }
+
+    fun deleteTagFromRepo(repoId: Int, tag: String, ghToken: String) {
+        val req = Request.Builder()
+            .from(getGitHubRefTagUri(repoId, tag), ghAppProperties.name, ghToken)
+            .delete()
+            .build()
+
+        httpClient.call(req)
     }
 
     fun getTeam(orgId: Int, teamId: Int, installationToken: String): GitHubTeamResponse {

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/remote/github/GitHubRoutes.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/remote/github/GitHubRoutes.kt
@@ -106,6 +106,7 @@ object GitHubRoutes {
     // Repositories
     const val GITHUB_REPOS_ID_URI = "$GITHUB_API_HOST/repositories"
     const val GITHUB_REPO_ID_URI = "$GITHUB_REPOS_ID_URI/{$REPO_ID_PARAM}"
+    const val GITHUB_REPO_ID_RELEASES_URI = "$GITHUB_REPO_ID_URI/releases"
     const val GITHUB_REPO_ID_GENERATE_URI = "$GITHUB_REPO_ID_URI/generate"
     const val GITHUB_REPO_COLLABORATORS_URI = "$GITHUB_REPO_ID_URI/collaborators"
     const val GITHUB_REPO_COLLABORATOR_URI = "$GITHUB_REPO_COLLABORATORS_URI/{$LOGIN_PARAM}"
@@ -115,12 +116,14 @@ object GitHubRoutes {
 
 
     val GITHUB_REPO_ID_URI_TEMPLATE = UriTemplate(GITHUB_REPO_ID_URI)
+    val GITHUB_REPO_ID_RELEASES_TEMPLATE = UriTemplate(GITHUB_REPO_ID_RELEASES_URI)
     val GITHUB_REPO_ID_GENERATE_URI_TEMPLATE = UriTemplate(GITHUB_REPO_ID_GENERATE_URI)
     val GITHUB_REPO_NAME_URI_TEMPLATE = UriTemplate(GITHUB_REPO_NAME_URI)
     val GITHUB_REPOS_OF_ORG_URI_TEMPLATE = UriTemplate(GITHUB_REPOS_OF_ORG_URI)
     val GITHUB_REPO_COLLABORATOR_URI_TEMPLATE = UriTemplate(GITHUB_REPO_COLLABORATOR_URI)
 
     fun getGitHubRepoByIdUri(repoId: Int) = GITHUB_REPO_ID_URI_TEMPLATE.expand(repoId)
+    fun getGitHubRepoReleasesByIdUri(repoId: Int) = GITHUB_REPO_ID_RELEASES_TEMPLATE.expand(repoId)
     fun getGitHubRepoGenerateByIdUri(repoId: Int) = GITHUB_REPO_ID_GENERATE_URI_TEMPLATE.expand(repoId)
     fun getGitHubRepoByNameUri(login: String, repoName: String) = GITHUB_REPO_NAME_URI_TEMPLATE.expand(login, repoName)
     fun getGitHubReposOfOrgUri(orgId: Int) = GITHUB_REPOS_OF_ORG_URI_TEMPLATE.expand(orgId)


### PR DESCRIPTION
This PR adds endpoints responsible for the submission and deletion of an assignment delivery on a given participant. 
* For the creation, the server application communicates with the GitHub API in order to create a release on the repository
* For the removal, the server application communicates with the GitHub API in order to remove a tag (removing the release consequentially).

Closes GH-89.