### PR TITLE
Limited heap size of Spring server

### DIFF
--- a/code/jvm/Dockerfile
+++ b/code/jvm/Dockerfile
@@ -14,4 +14,4 @@ ENV CODEGARTEN_CIPHER_KEY_PATH=secrets/cipher-key.txt
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-server", "-cp", "server:server/lib/*", "org.ionproject.codegarten.CodeGartenApplicationKt"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-Xmx256m", "-cp", "server:server/lib/*", "org.ionproject.codegarten.CodeGartenApplicationKt"]


### PR DESCRIPTION
This PR limits the heap size in the Spring server's Dockerfile. This was done in order to support hosting on an Heroku free Dyno.