### PR TITLE
Removed separate count queries in DB access

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ClassroomsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ClassroomsController.kt
@@ -69,7 +69,6 @@ class ClassroomsController(
         orgRole: GitHubUserOrgRole
     ): ResponseEntity<Response> {
         val classrooms = classroomsDb.getClassroomsOfUser(orgId, user.uid, pagination.page, pagination.limit)
-        val classroomsCount = classroomsDb.getClassroomsOfUserCount(orgId, user.uid)
         val org = gitHub.getOrgById(orgId, user.gh_token)
 
         val isOrgAdmin = orgRole == GitHubUserOrgRole.ADMIN
@@ -82,11 +81,11 @@ class ClassroomsController(
 
         return ClassroomsOutputModel(
             organization = org.login,
-            collectionSize = classroomsCount,
+            collectionSize = classrooms.count,
             pageIndex = pagination.page,
-            pageSize = classrooms.size,
+            pageSize = classrooms.results.size,
         ).toSirenObject(
-            entities = classrooms.map {
+            entities = classrooms.results.map {
                 ClassroomOutputModel(
                     id = it.cid,
                     inviteCode = if (isOrgAdmin) it.inv_code else null,
@@ -112,7 +111,7 @@ class ClassroomsController(
                 getClassroomsUri(orgId).includeHost(),
                 pagination.page,
                 pagination.limit,
-                classroomsCount
+                classrooms.count
             ) + listOf(
                 SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),
                 SirenLink(listOf("organizationGitHub"), getGithubLoginUri(org.login))

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
@@ -79,7 +79,6 @@ class DeliveriesController(
         assignment: Assignment
     ): ResponseEntity<Response> {
         val deliveries = deliveriesDb.getDeliveriesOfAssignment(orgId, classroomNumber, assignmentNumber, pagination.page, pagination.limit)
-        val deliveriesCount = deliveriesDb.getDeliveriesOfAssignmentCount(orgId, classroomNumber, assignmentNumber)
         val org = gitHub.getOrgById(orgId, user.gh_token)
 
         val actions = if (userClassroom.role == TEACHER) {
@@ -92,11 +91,11 @@ class DeliveriesController(
             assignment = assignment.name,
             classroom = userClassroom.classroom.name,
             organization = org.login,
-            collectionSize = deliveriesCount,
+            collectionSize = deliveries.count,
             pageIndex = pagination.page,
-            pageSize = deliveries.size
+            pageSize = deliveries.results.size
         ).toSirenObject(
-            entities = deliveries.map {
+            entities = deliveries.results.map {
                 DeliveryOutputModel(
                     id = it.did,
                     number = it.number,
@@ -122,7 +121,7 @@ class DeliveriesController(
                 Routes.getAssignmentsUri(orgId, classroomNumber).includeHost(),
                 pagination.page,
                 pagination.limit,
-                deliveriesCount
+                deliveries.count
             ) + listOf(
                 SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
                 SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
@@ -205,7 +204,6 @@ class DeliveriesController(
             }
 
         val deliveries = deliveriesDb.getDeliveriesOfAssignment(orgId, classroomNumber, assignmentNumber, pagination.page, pagination.limit)
-        val deliveriesCount = deliveriesDb.getDeliveriesOfAssignmentCount(orgId, classroomNumber, assignmentNumber)
 
         val ghTags = gitHub.getAllTagsFromRepo(repoId, user.gh_token)
         val org = gitHub.getOrgById(orgId, user.gh_token)
@@ -214,11 +212,11 @@ class DeliveriesController(
             assignment = assignment.name,
             classroom = userClassroom.classroom.name,
             organization = org.login,
-            collectionSize = deliveriesCount,
+            collectionSize = deliveries.count,
             pageIndex = pagination.page,
-            pageSize = deliveries.size
+            pageSize = deliveries.results.size
         ).toSirenObject(
-            entities = deliveries.map {
+            entities = deliveries.results.map {
                 ParticipantDeliveryItemOutputModel(
                     id = it.did,
                     number = it.number,
@@ -251,7 +249,7 @@ class DeliveriesController(
                 Routes.getAssignmentsUri(orgId, classroomNumber).includeHost(),
                 pagination.page,
                 pagination.limit,
-                deliveriesCount
+                deliveries.count
             ) + listOf(
                 SirenLink(listOf("deliveries"), getDeliveriesUri(orgId, classroomNumber, assignmentNumber).includeHost()),
                 SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/InvitationsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/InvitationsController.kt
@@ -112,8 +112,6 @@ class InvitationsController(
         user: User
     ): ResponseEntity<Response> {
         val inviteCode = inviteCodesDb.getInviteCode(inviteCodePath)
-
-        val teamsCount = teamsDb.getTeamsOfClassroomCount(inviteCode.classroom_id)
         val teams = teamsDb.getTeamsOfClassroom(inviteCode.classroom_id, pagination.page, pagination.limit)
         val org = gitHub.getOrgById(inviteCode.org_id, user.gh_token)
         val classroom = classroomsDb.getClassroomById(inviteCode.classroom_id)
@@ -121,11 +119,11 @@ class InvitationsController(
         return TeamsOutputModel(
             classroom = classroom.name,
             organization = org.login,
-            collectionSize = teamsCount,
+            collectionSize = teams.count,
             pageIndex = pagination.page,
-            pageSize = teams.size,
+            pageSize = teams.results.size,
         ).toSirenObject(
-            entities = teams.map {
+            entities = teams.results.map {
                 TeamItemOutputModel(
                     id = it.tid,
                     number = it.number,
@@ -143,7 +141,7 @@ class InvitationsController(
                 getUserInviteClassroomTeamsUri(inviteCodePath).includeHost(),
                 pagination.page,
                 pagination.limit,
-                teamsCount
+                teams.count
             ) + listOf(
                 SirenLink(listOf("invite"), getUserInviteUri(inviteCodePath).includeHost()),
             )

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ParticipantsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ParticipantsController.kt
@@ -348,15 +348,14 @@ class ParticipantsController(
         pagination: Pagination
     ): Siren<OutputModel> {
         val users = usersDb.getUsersInAssignment(orgId, classroomNumber, assignmentNumber, pagination.page, pagination.limit)
-        val usersCount = usersDb.getUsersInAssignmentCount(orgId, classroomNumber, assignmentNumber)
 
         return ParticipantsOutputModel(
             participantsType = ParticipantTypes.USER.type,
-            collectionSize = usersCount,
+            collectionSize = users.count,
             pageIndex = pagination.page,
-            pageSize = users.size
+            pageSize = users.results.size
         ).toSirenObject(
-            entities = users.map {
+            entities = users.results.map {
                 ParticipantItemOutputModel(
                     id = it.uid,
                     name = it.name
@@ -379,7 +378,7 @@ class ParticipantsController(
                 getParticipantsOfAssignmentUri(orgId, classroomNumber, assignmentNumber).includeHost(),
                 pagination.page,
                 pagination.limit,
-                usersCount
+                users.count
             ) + listOf(
                 SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
                 SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
@@ -393,15 +392,14 @@ class ParticipantsController(
         actions: List<SirenAction>?, pagination: Pagination
     ): Siren<OutputModel> {
         val teams = teamsDb.getTeamsFromAssignment(assignmentId, pagination.page, pagination.limit)
-        val teamsCount = teamsDb.getTeamsFromAssignmentCount(assignmentId)
 
         return ParticipantsOutputModel(
             participantsType = ParticipantTypes.TEAM.type,
-            collectionSize = teamsCount,
+            collectionSize = teams.count,
             pageIndex = pagination.page,
-            pageSize = teams.size
+            pageSize = teams.results.size
         ).toSirenObject(
-            entities = teams.map {
+            entities = teams.results.map {
                 ParticipantItemOutputModel(
                     id = it.tid,
                     name = it.name
@@ -424,7 +422,7 @@ class ParticipantsController(
                 getParticipantsOfAssignmentUri(orgId, classroomNumber, assignmentNumber).includeHost(),
                 pagination.page,
                 pagination.limit,
-                teamsCount
+                teams.count
             ) + listOf(
                 SirenLink(listOf("assignment"), getAssignmentByNumberUri(orgId, classroomNumber, assignmentNumber).includeHost()),
                 SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/TeamsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/TeamsController.kt
@@ -64,13 +64,10 @@ class TeamsController(
         user: User,
         userClassroom: UserClassroom
     ): ResponseEntity<Response> {
-        val teamsCount: Int
         val teams =
             if (userClassroom.role == TEACHER) {
-                teamsCount = teamsDb.getTeamsOfClassroomCount(orgId, classroomNumber)
                 teamsDb.getTeamsOfClassroom(orgId, classroomNumber, pagination.page, pagination.limit)
             } else {
-                teamsCount = teamsDb.getTeamsOfClassroomOfUserCount(orgId, classroomNumber, user.uid)
                 teamsDb.getTeamsOfClassroomOfUser(orgId, classroomNumber, user.uid, pagination.page, pagination.limit)
             }
 
@@ -85,11 +82,11 @@ class TeamsController(
         return TeamsOutputModel(
             classroom = userClassroom.classroom.name,
             organization = org.login,
-            collectionSize = teamsCount,
+            collectionSize = teams.count,
             pageIndex = pagination.page,
-            pageSize = teams.size,
+            pageSize = teams.results.size,
         ).toSirenObject(
-            entities = teams.map {
+            entities = teams.results.map {
                 TeamItemOutputModel(
                     id = it.tid,
                     number = it.number,
@@ -113,7 +110,7 @@ class TeamsController(
                 Routes.getClassroomsUri(orgId).includeHost(),
                 pagination.page,
                 pagination.limit,
-                teamsCount
+                teams.count
             ) + listOf(
                 SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
                 SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()),

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/UsersController.kt
@@ -155,13 +155,9 @@ class UsersController(
         user: User,
         userClassroom: UserClassroom
     ): ResponseEntity<Response> {
-        val usersCount: Int
-
         val users = if (search.isNullOrEmpty()) {
-            usersCount = usersDb.getUsersInClassroomCount(orgId, classroomNumber)
             usersDb.getUsersInClassroom(orgId, classroomNumber, pagination.page, pagination.limit)
         } else {
-            usersCount = usersDb.searchUsersInClassroomCount(orgId, classroomNumber, search)
             usersDb.searchUsersInClassroom(orgId, classroomNumber, search, pagination.page, pagination.limit)
         }
 
@@ -175,11 +171,11 @@ class UsersController(
                 null
 
         return UsersOutputModel(
-            collectionSize = usersCount,
+            collectionSize = users.count,
             pageIndex = pagination.page,
-            pageSize = users.size
+            pageSize = users.results.size
         ).toSirenObject(
-            entities = users.map {
+            entities = users.results.map {
                 UserClassroomOutputModel(
                     id = it.uid,
                     name = it.name,
@@ -198,7 +194,7 @@ class UsersController(
                 getUsersOfClassroomUri(orgId, classroomNumber).includeHost(),
                 pagination.page,
                 pagination.limit,
-                usersCount
+                users.count
             ) + listOf(
                 SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),
                 SirenLink(listOf("organization"), getOrgByIdUri(orgId).includeHost()))
@@ -287,7 +283,6 @@ class UsersController(
             throw ForbiddenException("User is not in team")
 
         val users = usersDb.getUsersInTeam(team.tid, pagination.page, pagination.limit)
-        val usersCount = usersDb.getUsersInTeamCount(team.tid)
 
         val actions =
             if (userClassroom.role == TEACHER)
@@ -299,11 +294,11 @@ class UsersController(
                 null
 
         return UsersOutputModel(
-            collectionSize = usersCount,
+            collectionSize = users.count,
             pageIndex = pagination.page,
-            pageSize = users.size
+            pageSize = users.results.size
         ).toSirenObject(
-            entities = users.map {
+            entities = users.results.map {
                 UserItemOutputModel(
                     id = it.uid,
                     name = it.name
@@ -322,7 +317,7 @@ class UsersController(
                 getUsersOfTeamUri(orgId, classroomNumber, teamNumber).includeHost(),
                 pagination.page,
                 pagination.limit,
-                usersCount
+                users.count
             ) + listOf(
                 SirenLink(listOf("team"), getTeamByNumberUri(orgId, classroomNumber, teamNumber).includeHost()),
                 SirenLink(listOf("classroom"), getClassroomByNumberUri(orgId, classroomNumber).includeHost()),

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Assignment.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Assignment.kt
@@ -14,6 +14,8 @@ data class Assignment(
     val classroom_id: Int,
     val classroom_number: Int,
     val classroom_name: String,
+
+    val count: Int? = null
 )
 
 data class CreatedAssignment(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Classroom.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Classroom.kt
@@ -7,4 +7,6 @@ data class Classroom(
     val org_id: Int,
     val name: String,
     val description: String?,
+
+    val count: Int? = null
 )

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Delivery.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Delivery.kt
@@ -16,6 +16,8 @@ data class Delivery(
     val classroom_id: Int,
     val classroom_number: Int,
     val classroom_name: String,
+
+    val count: Int? = null
 )
 
 data class CreatedDelivery(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/DtoListWrapper.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/DtoListWrapper.kt
@@ -1,0 +1,6 @@
+package org.ionproject.codegarten.database.dto
+
+data class DtoListWrapper<T>(
+    val count: Int,
+    val results: List<T>
+)

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Team.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/Team.kt
@@ -10,6 +10,8 @@ data class Team(
     val classroom_id: Int,
     val classroom_number: Int,
     val classroom_name: String,
+
+    val count: Int? = null
 )
 
 data class CreatedTeam(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/TeamAssignment.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/TeamAssignment.kt
@@ -6,4 +6,6 @@ data class TeamAssignment(
     val name: String,
     val gh_id: Int,
     val repo_id: Int,
+
+    val count: Int? = null
 )

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/User.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/User.kt
@@ -5,4 +5,6 @@ data class User(
     val name: String,
     val gh_id: Int,
     val gh_token: String,
+
+    val count: Int? = null
 )

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/UserAssignment.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/UserAssignment.kt
@@ -6,4 +6,6 @@ data class UserAssignment(
     val gh_id: Int,
     val gh_token: String,
     val repo_id: Int,
+
+    val count: Int? = null
 )

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/UserClassroomMembership.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/dto/UserClassroomMembership.kt
@@ -6,7 +6,9 @@ data class UserClassroomDto(
     val gh_id: Int,
     val gh_token: String,
     val classroom_role: String,
-    val classroom_id: Int
+    val classroom_id: Int,
+
+    val count: Int? = null
 )
 
 data class UserClassroom(

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/AssignmentsDb.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/AssignmentsDb.kt
@@ -2,31 +2,30 @@ package org.ionproject.codegarten.database.helpers
 
 import org.ionproject.codegarten.database.dto.Assignment
 import org.ionproject.codegarten.database.dto.CreatedAssignment
+import org.ionproject.codegarten.database.dto.DtoListWrapper
 import org.jdbi.v3.core.Jdbi
 import org.springframework.stereotype.Component
 
-private const val GET_ASSIGNMENTS_BASE =
+private const val GET_ASSIGNMENT_BASE =
     "SELECT aid, number, inv_code, name, description, type, repo_prefix, repo_template, org_id, classroom_id, classroom_number, classroom_name FROM V_ASSIGNMENT"
+private const val GET_ASSIGNMENTS_BASE =
+    "SELECT aid, number, inv_code, name, description, type, repo_prefix, repo_template, org_id, classroom_id, classroom_number, classroom_name, COUNT(*) OVER() as count FROM V_ASSIGNMENT"
+
 private const val GET_ASSIGNMENT_QUERY =
-    "$GET_ASSIGNMENTS_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber AND number = :number"
+    "$GET_ASSIGNMENT_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber AND number = :number"
 private const val GET_ASSIGNMENT_BY_ID_QUERY =
-    "$GET_ASSIGNMENTS_BASE WHERE aid = :assignmentId"
+    "$GET_ASSIGNMENT_BASE WHERE aid = :assignmentId"
 private const val GET_ASSIGNMENT_BY_INVCODE_QUERY =
-    "$GET_ASSIGNMENTS_BASE WHERE inv_code = :inviteCode"
+    "$GET_ASSIGNMENT_BASE WHERE inv_code = :inviteCode"
 
 private const val GET_ASSIGNMENTS_OF_CLASSROOM_QUERY =
     "$GET_ASSIGNMENTS_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber ORDER BY number"
-private const val GET_ASSIGNMENTS_OF_CLASSROOM_COUNT =
-    "SELECT COUNT(aid) as count FROM V_ASSIGNMENT WHERE org_id = :orgId AND classroom_number = :classroomNumber"
 
 private const val GET_ASSIGNMENTS_IDS_OF_USER_QUERY =
     "SELECT aid FROM USER_ASSIGNMENT WHERE uid = :userId UNION SELECT aid FROM V_TEAM_USER_ASSIGNMENT WHERE uid = :userId"
 private const val GET_ASSIGNMENTS_OF_USER_QUERY =
     "$GET_ASSIGNMENTS_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber AND " +
     "aid IN ($GET_ASSIGNMENTS_IDS_OF_USER_QUERY) ORDER BY number"
-private const val GET_ASSIGNMENTS_OF_USER_COUNT =
-    "SELECT COUNT(aid) as count FROM V_ASSIGNMENT WHERE org_id = :orgId AND classroom_number = :classroomNumber AND " +
-    "aid IN ($GET_ASSIGNMENTS_IDS_OF_USER_QUERY)"
 
 private const val CREATE_ASSIGNMENT_QUERY =
     "INSERT INTO ASSIGNMENT(cid, name, description, type, repo_prefix, repo_template) VALUES" +
@@ -64,35 +63,31 @@ class AssignmentsDb(
             mapOf("inviteCode" to inviteCode)
         )
 
-    fun getAllAssignments(orgId: Int, classroomNumber: Int, page: Int, limit: Int): List<Assignment> {
-        return jdbi.getList(
+    fun getAllAssignments(orgId: Int, classroomNumber: Int, page: Int, limit: Int): DtoListWrapper<Assignment> {
+        val results = jdbi.getList(
             GET_ASSIGNMENTS_OF_CLASSROOM_QUERY,
             Assignment::class.java, page, limit,
             mapOf("orgId" to orgId, "classroomNumber" to classroomNumber)
         )
+
+        return DtoListWrapper(
+            count = if (results.isEmpty()) 0 else results[0].count!!,
+            results = results
+        )
     }
 
-    fun getAllAssignmentsCount(orgId: Int, classroomNumber: Int): Int =
-        jdbi.getOne(
-            GET_ASSIGNMENTS_OF_CLASSROOM_COUNT,
-            Int::class.java,
-            mapOf("orgId" to orgId, "classroomNumber" to classroomNumber)
-        )
-
-    fun getAssignmentsOfUser(orgId: Int, classroomNumber: Int, userId: Int, page: Int, limit: Int): List<Assignment> {
-        return jdbi.getList(
+    fun getAssignmentsOfUser(orgId: Int, classroomNumber: Int, userId: Int, page: Int, limit: Int): DtoListWrapper<Assignment> {
+        val results = jdbi.getList(
             GET_ASSIGNMENTS_OF_USER_QUERY,
             Assignment::class.java, page, limit,
             mapOf("orgId" to orgId, "classroomNumber" to classroomNumber, "userId" to userId)
         )
-    }
 
-    fun getAssignmentsOfUserCount(orgId: Int, classroomNumber: Int, userId: Int) =
-        jdbi.getOne(
-            GET_ASSIGNMENTS_OF_USER_COUNT,
-            Int::class.java,
-            mapOf("orgId" to orgId, "classroomNumber" to classroomNumber, "userId" to userId)
+        return DtoListWrapper(
+            count = if (results.isEmpty()) 0 else results[0].count!!,
+            results = results
         )
+    }
 
     fun createAssignment(
         orgId: Int, classroomNumber: Int, name: String, description: String? = null, type: String,
@@ -126,7 +121,7 @@ class AssignmentsDb(
             org_id = classroom.org_id,
             classroom_id = classroom.cid,
             classroom_number = classroom.number,
-            classroom_name = classroom.name,
+            classroom_name = classroom.name
         )
     }
 

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/DeliveriesDb.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/database/helpers/DeliveriesDb.kt
@@ -2,24 +2,26 @@ package org.ionproject.codegarten.database.helpers
 
 import org.ionproject.codegarten.database.dto.CreatedDelivery
 import org.ionproject.codegarten.database.dto.Delivery
+import org.ionproject.codegarten.database.dto.DtoListWrapper
 import org.jdbi.v3.core.Jdbi
 import org.springframework.stereotype.Component
 import java.time.OffsetDateTime
 
-private const val GET_DELIVERIES_BASE =
+private const val GET_DELIVERY_BASE =
     "SELECT did, number, tag, due_date, assignment_id, assignment_number, assignment_name, " +
     "org_id, classroom_id, classroom_number, classroom_name FROM V_DELIVERY"
+private const val GET_DELIVERIES_BASE =
+    "SELECT did, number, tag, due_date, assignment_id, assignment_number, assignment_name, " +
+            "org_id, classroom_id, classroom_number, classroom_name, COUNT(*) OVER() as count FROM V_DELIVERY"
+
 private const val GET_DELIVERY_QUERY =
-    "$GET_DELIVERIES_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber AND " +
+    "$GET_DELIVERY_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber AND " +
     "assignment_number = :assignmentNumber AND number = :number"
-private const val GET_DELIVERY_BY_ID_QUERY = "$GET_DELIVERIES_BASE WHERE did = :deliveryId"
+private const val GET_DELIVERY_BY_ID_QUERY = "$GET_DELIVERY_BASE WHERE did = :deliveryId"
 
 private const val GET_DELIVERIES_OF_ASSIGNMENT_QUERY =
     "$GET_DELIVERIES_BASE WHERE org_id = :orgId AND classroom_number = :classroomNumber AND " +
     "assignment_number = :assignmentNumber ORDER BY due_date, number"
-private const val GET_DELIVERIES_OF_ASSIGNMENT_COUNT =
-    "SELECT COUNT(did) as count from V_DELIVERY WHERE org_id = :orgId AND " +
-    "classroom_number = :classroomNumber AND assignment_number = :assignmentNumber"
 
 private const val CREATE_DELIVERY_QUERY =
     "INSERT INTO DELIVERY(aid, tag, due_date) VALUES(:assignmentId, :tag, :dueDate)"
@@ -47,19 +49,18 @@ class DeliveriesDb(
             )
         )
 
-    fun getDeliveriesOfAssignment(orgId: Int, classroomNumber: Int, assignmentNumber: Int, page: Int, limit: Int) =
-        jdbi.getList(
+    fun getDeliveriesOfAssignment(orgId: Int, classroomNumber: Int, assignmentNumber: Int, page: Int, limit: Int): DtoListWrapper<Delivery> {
+        val results = jdbi.getList(
             GET_DELIVERIES_OF_ASSIGNMENT_QUERY,
             Delivery::class.java, page, limit,
             mapOf("orgId" to orgId, "classroomNumber" to classroomNumber, "assignmentNumber" to assignmentNumber)
         )
 
-    fun getDeliveriesOfAssignmentCount(orgId: Int, classroomNumber: Int, assignmentNumber: Int) =
-        jdbi.getOne(
-            GET_DELIVERIES_OF_ASSIGNMENT_COUNT,
-            Int::class.java,
-            mapOf("orgId" to orgId, "classroomNumber" to classroomNumber, "assignmentNumber" to assignmentNumber)
+        return DtoListWrapper(
+            count = if (results.isEmpty()) 0 else results[0].count!!,
+            results = results
         )
+    }
 
     fun createDelivery(orgId: Int, classroomNumber: Int, assignmentNumber: Int,
                        tag: String, dueDate: OffsetDateTime? = null): Delivery {


### PR DESCRIPTION
This PR removes the dedicated count queries that currently exist in database access. Now the total amount of rows is obtained in the same query that gets the results. Even if these queries are slower, it should still be faster than making two separate ones.

Closes GH-97.