### PR TITLE
Add validation for delivery tags

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
@@ -30,6 +30,7 @@ import org.ionproject.codegarten.controllers.models.DeliveryEditInputModel
 import org.ionproject.codegarten.controllers.models.DeliveryOutputModel
 import org.ionproject.codegarten.controllers.models.ParticipantDeliveryItemOutputModel
 import org.ionproject.codegarten.controllers.models.ParticipantDeliveryOutputModel
+import org.ionproject.codegarten.controllers.models.isTagValid
 import org.ionproject.codegarten.database.dto.Assignment
 import org.ionproject.codegarten.database.dto.User
 import org.ionproject.codegarten.database.dto.UserClassroom
@@ -193,6 +194,7 @@ class DeliveriesController(
 
         if (input == null) throw InvalidInputException("Missing body")
         if (input.tag == null) throw InvalidInputException("Missing tag")
+        if (!input.isTagValid()) throw InvalidInputException("Invalid tag")
 
         val dueDate = try {
             if (input.dueDate != null) OffsetDateTime.parse(input.dueDate)
@@ -247,6 +249,7 @@ class DeliveriesController(
         if (userClassroom.role != TEACHER) throw ForbiddenException("User is not a teacher")
 
         if (input == null) throw InvalidInputException("Missing body")
+        if (input.tag != null && !input.isTagValid()) throw InvalidInputException("Invalid tag")
 
         val deleteDate: Boolean
         val dueDate = try {

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Deliveries.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/models/Deliveries.kt
@@ -3,6 +3,8 @@ package org.ionproject.codegarten.controllers.models
 import org.ionproject.codegarten.responses.siren.SirenClass.collection
 import org.ionproject.codegarten.responses.siren.SirenClass.delivery
 import java.time.OffsetDateTime
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 class DeliveryOutputModel(
     val id: Int,
@@ -63,3 +65,15 @@ data class DeliveryEditInputModel(
     val tag: String?,
     val dueDate: String?
 )
+
+fun DeliveryCreateInputModel.isTagValid() = isTagValid(this.tag!!)
+fun DeliveryEditInputModel.isTagValid() = isTagValid(this.tag!!)
+
+private fun isTagValid(tag: String): Boolean {
+    val regex = "^(?!/|.*([/.]\\.|//|@\\{|\\\\\\\\))[^\\040\\0177~^:?*\\[]+(?<!\\.lock|[/.]|-)$"
+
+    val pattern: Pattern = Pattern.compile(regex)
+    val matcher: Matcher = pattern.matcher(tag)
+
+    return matcher.find()
+}


### PR DESCRIPTION
This PR adds validation for creating and editing deliveries. The validation is made on the field `tag` in order to be consistent with the GitHub tags restrictions.

Closes GH-64.