### PR TITLE
Use browser cookies to store access token

### DIFF
--- a/code/js/.gitignore
+++ b/code/js/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+secrets

--- a/code/js/Dockerfile
+++ b/code/js/Dockerfile
@@ -4,8 +4,11 @@ WORKDIR /app
 
 COPY ./node_modules ./node_modules
 COPY ./public ./public
+COPY secrets ./secrets
 COPY ./dist ./dist
 COPY ./views ./views
+
+ENV CODEGARTEN_WEB_CIPHER_KEY_PATH=secrets/cipher-key.txt
 
 EXPOSE 80
 

--- a/code/js/lib/user-control.ts
+++ b/code/js/lib/user-control.ts
@@ -71,8 +71,7 @@ function getAccessToken(req: Request): AccessToken {
 
             try {
                 const decipher = crypto.createDecipheriv(CIPHER_ALGORITHM, SECRET_KEY, iv)
-                const a = accessToken.slice(16)
-                const decrypted = decipher.update(a, 'base64', 'utf8')
+                const decrypted = decipher.update(accessToken.slice(16), 'base64', 'utf8')
                 return JSON.parse(decrypted + decipher.final('utf8'))
             } catch(error) {
                 return null
@@ -85,11 +84,11 @@ function getAccessToken(req: Request): AccessToken {
 }
 
 function setAccessToken(res: Response, accessToken: AccessToken): void {
-    const yes = crypto.randomBytes(8).toString('hex')
-    const cipher = crypto.createCipheriv(CIPHER_ALGORITHM, SECRET_KEY, yes)
+    const iv = crypto.randomBytes(8).toString('hex')
+    const cipher = crypto.createCipheriv(CIPHER_ALGORITHM, SECRET_KEY, iv)
     let encrypted = cipher.update(JSON.stringify(accessToken), 'utf8', 'base64')
     encrypted += cipher.final('base64')
-    res.setHeader('Set-Cookie', [`${ACCESS_TOKEN_COOKIE}=${yes + encrypted}; Path=/; expires=${accessToken.expiresAt}; HttpOnly; SameSite=Lax`])
+    res.setHeader('Set-Cookie', [`${ACCESS_TOKEN_COOKIE}=${iv + encrypted}; Path=/; expires=${accessToken.expiresAt}; HttpOnly; SameSite=Lax`])
 }
 
 function removeAccessToken(res: Response) {

--- a/code/js/lib/user-control.ts
+++ b/code/js/lib/user-control.ts
@@ -4,40 +4,44 @@ import { NextFunction, Request, Response } from 'express'
 import { getAuthenticatedUser } from './repo/services/users'
 import { authRoutes } from './repo/api-routes'
 import { revokeAccessToken } from './repo/services/auth'
+import * as crypto from 'crypto'
+import * as fs from 'fs'
 
 const ACCESS_TOKEN_VALIDITY_THRESHOLD = 1000 * 60 * 60 * 24 // 1 day
+const ACCESS_TOKEN_COOKIE = 'tok'
+
+const SECRET_KEY = fs.readFileSync(`${process.env.CODEGARTEN_WEB_CIPHER_KEY_PATH}`)
+const CIPHER_ALGORITHM = 'aes-256-cbc'
 
 export = function(req: Request, res: Response, next: NextFunction): void {
     req.login = function(user: AuthenticatedUser): Promise<boolean> {
-        req.session.accessToken = user.accessToken
+        setAccessToken(res, user.accessToken)
 
         console.log(`[LOGIN] ${user.username}`)
         return Promise.resolve(true)
     }
-    req.logout = function(): Promise<boolean> {
+    req.logout = async function(): Promise<boolean> {
         const username = req.user?.username
-        const token = req.session.accessToken
+        const token = getAccessToken(req)
 
-        return revokeAccessToken(token.token)
-            .then(res => {
-                if (res.status == 200) { 
-                    req.user = null
-                    req.session.accessToken = null
-                    console.log(`[LOGOUT] ${username}`)
-                    return true
-                } else {
-                    console.log(`[LOGOUT FAIL] ${username}`)
-                    return false
-                }
-            })
+        const apiRes = await revokeAccessToken(token.token)
+        if (apiRes.status == 200) {
+            req.user = null
+            removeAccessToken(res)
+            console.log(`[LOGOUT] ${username}`)
+            return true
+        } else {
+            console.log(`[LOGOUT FAIL] ${username}`)
+            return false
+        }
     }
 
-    const accessToken = req.session.accessToken
+    const accessToken = getAccessToken(req)
     if (accessToken) {
         const date = new Date(new Date().getTime() + ACCESS_TOKEN_VALIDITY_THRESHOLD)
         const expirDate = new Date(accessToken.expiresAt)
         if (expirDate <= date) {
-            req.session.accessToken = null
+            removeAccessToken(res)
             req.session.redirectUri = req.url
             return res.redirect(authRoutes.getAuthCodeUri)
         }
@@ -50,4 +54,44 @@ export = function(req: Request, res: Response, next: NextFunction): void {
                     .then(() => next())
             })
     } else next()
+}
+
+function getAccessToken(req: Request): AccessToken {
+    if (req.headers.cookie) {
+        const rawCookies = req.headers.cookie.split('; ')
+
+        const parsedCookies = {}
+        rawCookies.forEach(rawCookie => {
+            const parsedCookie = rawCookie.split('=')
+            parsedCookies[parsedCookie[0]] = parsedCookie[1]
+        })
+        const accessToken: string = parsedCookies[ACCESS_TOKEN_COOKIE]
+        if (accessToken) {
+            const iv = accessToken.slice(0, 16)
+
+            try {
+                const decipher = crypto.createDecipheriv(CIPHER_ALGORITHM, SECRET_KEY, iv)
+                const a = accessToken.slice(16)
+                const decrypted = decipher.update(a, 'base64', 'utf8')
+                return JSON.parse(decrypted + decipher.final('utf8'))
+            } catch(error) {
+                return null
+            }
+        } else {
+            return null
+        }
+    }
+    return null
+}
+
+function setAccessToken(res: Response, accessToken: AccessToken): void {
+    const yes = crypto.randomBytes(8).toString('hex')
+    const cipher = crypto.createCipheriv(CIPHER_ALGORITHM, SECRET_KEY, yes)
+    let encrypted = cipher.update(JSON.stringify(accessToken), 'utf8', 'base64')
+    encrypted += cipher.final('base64')
+    res.setHeader('Set-Cookie', [`${ACCESS_TOKEN_COOKIE}=${yes + encrypted}; Path=/; expires=${accessToken.expiresAt}; HttpOnly; SameSite=Lax`])
+}
+
+function removeAccessToken(res: Response) {
+    res.setHeader('Set-Cookie', [`${ACCESS_TOKEN_COOKIE}=expired; Max-Age=-99999999`])
 }

--- a/code/js/secrets-example/README.md
+++ b/code/js/secrets-example/README.md
@@ -1,0 +1,2 @@
+This folder contains sensitive information, as in, the cipher key used to encrypt the cookies.
+The key present in the file should be replaced with another one, and this folder should be renamed to `secrets`.

--- a/code/js/secrets-example/README.md
+++ b/code/js/secrets-example/README.md
@@ -1,2 +1,2 @@
-This folder contains sensitive information, as in, the cipher key used to encrypt the cookies.
-The key present in the file should be replaced with another one, and this folder should be renamed to `secrets`.
+This folder contains an example on how to set up a cipher key file, contain a key to encrypt the app's cookies.
+The key present in this file should be replaced with another one.

--- a/code/js/secrets-example/cipher-key.txt
+++ b/code/js/secrets-example/cipher-key.txt
@@ -1,0 +1,1 @@
+a-secure-cipher-key-with-32bytes


### PR DESCRIPTION
This PR changes the way the web app stores access tokens. They're now stored in the browser's cookies, encrypted with a cipher key. This cipher key should be in a file, and that file's path **should be defined in the `CODEGARTEN_WEB_CIPHER_KEY_PATH` environment variable**.

Closes GH-49.