### PR TITLE
Fix issue in participant Id for group assignments

### DIFF
--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/DeliveriesController.kt
@@ -41,7 +41,6 @@ import org.ionproject.codegarten.database.dto.isGroupAssignment
 import org.ionproject.codegarten.database.helpers.DeliveriesDb
 import org.ionproject.codegarten.database.helpers.TeamsDb
 import org.ionproject.codegarten.database.helpers.UsersDb
-import org.ionproject.codegarten.exceptions.ConflictException
 import org.ionproject.codegarten.exceptions.ForbiddenException
 import org.ionproject.codegarten.exceptions.HttpRequestException
 import org.ionproject.codegarten.exceptions.InvalidInputException

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ParticipantsController.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/ParticipantsController.kt
@@ -400,7 +400,7 @@ class ParticipantsController(
         ).toSirenObject(
             entities = teams.results.map {
                 ParticipantItemOutputModel(
-                    id = it.tid,
+                    id = it.number,
                     name = it.name
                 ).toSirenObject(
                     rel = listOf("item"),

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/actions/DeliveryActions.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/controllers/api/actions/DeliveryActions.kt
@@ -1,6 +1,5 @@
 package org.ionproject.codegarten.controllers.api.actions
 
-import org.ionproject.codegarten.Routes
 import org.ionproject.codegarten.Routes.INPUT_CONTENT_TYPE
 import org.ionproject.codegarten.Routes.getDeliveriesUri
 import org.ionproject.codegarten.Routes.getDeliveryByNumberUri

--- a/code/jvm/src/main/kotlin/org/ionproject/codegarten/remote/github/GitHubInterface.kt
+++ b/code/jvm/src/main/kotlin/org/ionproject/codegarten/remote/github/GitHubInterface.kt
@@ -18,7 +18,6 @@ import org.ionproject.codegarten.remote.from
 import org.ionproject.codegarten.remote.github.GitHubCacheTimes.ORG_INFO_CACHE
 import org.ionproject.codegarten.remote.github.GitHubCacheTimes.ORG_MEMBERSHIP_CACHE
 import org.ionproject.codegarten.remote.github.GitHubCacheTimes.REPO_INFO_CACHE
-import org.ionproject.codegarten.remote.github.GitHubCacheTimes.REPO_TAGS_CACHE
 import org.ionproject.codegarten.remote.github.GitHubCacheTimes.REPO_TAG_CACHE
 import org.ionproject.codegarten.remote.github.GitHubCacheTimes.TEAM_INFO_CACHE
 import org.ionproject.codegarten.remote.github.GitHubCacheTimes.USER_INFO_CACHE


### PR DESCRIPTION
This PR fixes an issue in order to show the correct participant id of a team in a group assignment.