### PR TITLE
Fix wrong link in classroom list

### DIFF
--- a/code/js/views/list-classrooms.hbs
+++ b/code/js/views/list-classrooms.hbs
@@ -64,7 +64,7 @@
                         <h3 class="card-title">{{name}}</h3>
                         <p class="card-text">{{description}}</p>
                         <div class="mt-auto">
-                            <a class="btn btn-primary card-link" href="/orgs/{{../orgId}}/classrooms/{{id}}">View classroom</a>
+                            <a class="btn btn-primary card-link" href="/orgs/{{../orgId}}/classrooms/{{number}}">View classroom</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR fixes an issue in the Web App, where the link for the classroom in their list was using the ID instead of their number.

Closes GH-116.